### PR TITLE
Fix link to GitHub repo from site header

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -13,5 +13,5 @@ navbar:
     - text: "ROS View"
       href: ros-view.html
     - text: "GitHub"
-      href: https://github.com/dynastyprocess/expectedpoints
+      href: https://github.com/dynastyprocess/ep_site
 output: distill::distill_article


### PR DESCRIPTION
The site header links to "GitHub" but the destination doesn't exist (404 error). I think the correct repo is https://github.com/dynastyprocess/ep_site instead.